### PR TITLE
fix(deps): Move lodash to dependencies for SSR compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,9 @@
     "Twyzle Team"
   ],
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
-  },
-  "peerDependenciesMeta": {
-    "lodash": {
-      "optional": true
-    },
-    "lodash-es": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",


### PR DESCRIPTION
This change addresses an issue where the library fails in Server-Side Rendering (SSR) environments like Nuxt.js.

The root cause was that `lodash-es` was declared as a `peerDependency`. While this works for client-side bundling, it causes module resolution errors in Node.js-based SSR environments because they can struggle to correctly resolve ES Modules provided by a parent project.

By moving `lodash` and `lodash-es` to `dependencies`, the library becomes self-contained. The build process (`tsup`) ensures that the dependencies are correctly bundled or referenced in a way that is compatible with both CommonJS (`require`) and ES Modules (`import`), making the library work reliably across different environments without requiring special configuration from the end-user.